### PR TITLE
DuhBash: fixup!: backup, restore hardcoded to config dirs

### DIFF
--- a/dot.sh
+++ b/dot.sh
@@ -37,8 +37,8 @@ case $EXIT_STATUS in
             IFS=" " read -r TABLE_CONFIG_DIRS <<< "$(toml_get "${TABLE}" config)"
             IFS=" " read -r TABLE_LOCAL_DIRS <<< "$(toml_get "${TABLE}" local)"
 
-            backup "${TABLE}" "TABLE_CONFIG_DIRS"
-            backup "${TABLE}" "TABLE_LOCAL_DIRS"
+            backup "${TABLE}" "TABLE_CONFIG_DIRS" "CONFIG_DIR"
+            backup "${TABLE}" "TABLE_LOCAL_DIRS" "LOCAL_DIR"
         done
         ;;
     1)
@@ -53,8 +53,8 @@ case $EXIT_STATUS in
                     IFS=" " read -r TABLE_CONFIG_DIRS <<< "$(toml_get "${TABLE}" config)"
                     IFS=" " read -r TABLE_LOCAL_DIRS <<< "$(toml_get "${TABLE}" local)"
 
-                    restore "${TABLE}" "TABLE_CONFIG_DIRS"
-                    restore "${TABLE}" "TABLE_LOCAL_DIRS"
+                    restore "${TABLE}" "TABLE_CONFIG_DIRS" "CONFIG_DIR"
+                    restore "${TABLE}" "TABLE_LOCAL_DIRS" "LOCAL_DIR"
                 done
                 ;;
             1)

--- a/utils.sh
+++ b/utils.sh
@@ -113,6 +113,7 @@ copy() {
 backup() {
     local TABLE=$1
     local -n TABLE_DIRS=$2
+    local -n EXTRACT_DIR=$3
     local TOML_CHECK
     TOML_CHECK=$(check_toml_get "${!TABLE_DIRS}")
 
@@ -120,9 +121,9 @@ backup() {
         # shellcheck disable=2068
         for TABLE_DIR in ${TABLE_DIRS[@]}; do
             if [[ "${TABLE}" ==  "${TABLE_DIR}" ]]; then
-                copy "${CONFIG_DIR}/${TABLE_DIR}" "${STORE_DIR}" "${TABLE}"
+                copy "${EXTRACT_DIR}/${TABLE_DIR}" "${STORE_DIR}" "${TABLE}"
             else
-                copy "${CONFIG_DIR}/${TABLE_DIR}" "${STORE_DIR}/${TABLE}" "${TABLE}"
+                copy "${EXTRACT_DIR}/${TABLE_DIR}" "${STORE_DIR}/${TABLE}" "${TABLE}"
             fi
         done
     fi
@@ -131,6 +132,7 @@ backup() {
 restore() {
     local TABLE=$1
     local -n TABLE_DIRS=$2
+    local -n RESTORE_DIR=$3
     local TOML_CHECK
     TOML_CHECK=$(check_toml_get "${!TABLE_DIRS}")
 
@@ -138,9 +140,9 @@ restore() {
         # shellcheck disable=2068
         for TABLE_DIR in ${TABLE_DIRS[@]}; do
             if [[ "${TABLE}" ==  "${TABLE_DIR}" ]]; then
-                copy "${STORE_DIR}/${TABLE}" "${CONFIG_DIR}" "${TABLE}"
+                copy "${STORE_DIR}/${TABLE}" "${RESTORE_DIR}" "${TABLE}"
             else
-                copy "${STORE_DIR}/${TABLE}/${TABLE_DIR}" "${CONFIG_DIR}" "${TABLE}"
+                copy "${STORE_DIR}/${TABLE}/${TABLE_DIR}" "${RESTORE_DIR}" "${TABLE}"
             fi
         done
     fi


### PR DESCRIPTION
bug:
- the backup and restore functions are hardcoded for config only
- which is wrong as we support .local backups

fix:
- pass a new argument $3 to declare config and local